### PR TITLE
Minimise number of layers, update node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM ubuntu:14.04
 MAINTAINER Vinicius Souza <hi@vsouza.com>
 
-RUN apt-get update
-RUN apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup | sudo bash -
-RUN apt-get -y install nodejs
-RUN apt-get -y install build-essential
-RUN npm install -g kinesalite
+RUN set -eu \
+   && apt-get update \
+   && apt-get install -y curl \
+   && curl -sL https://deb.nodesource.com/setup_10.x | sudo bash - \
+   && apt-get -y install nodejs \
+   && apt-get -y install build-essential \
+   && npm install -g kinesalite \
+   && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 4567
 


### PR DESCRIPTION
There is a Docker guideline:

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers

and the build fails with following error, this PR fixes it

```
Node.js 0.10 is no longer actively supported!

  You will not receive security or critical stability updates for this version.

  You should migrate to a supported version of Node.js as soon as possible.
  Use the installation script that corresponds to the version of Node.js you
  wish to install. e.g.

   * https://deb.nodesource.com/setup_8.x — Node.js 8 LTS "Carbon" (recommended)
   * https://deb.nodesource.com/setup_10.x — Node.js 10 Current

  Please see https://github.com/nodejs/Release for details about which
  version may be appropriate for you.

  The NodeSource Node.js distributions repository contains
  information both about supported versions of Node.js and supported Linux
  distributions. To learn more about usage, see the repository:
    https://github.com/nodesource/distributions
```